### PR TITLE
Milestone 6: Friendships v2

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -5,8 +5,10 @@ class FriendshipsController < ApplicationController
 
     if @friendship.save
       redirect_to users_path
+      flash.notice = 'Friendship request sucesffully sent'
     else
       redirect_to posts_path
+      flash.alert = 'Friendship request unsuccessful'
     end
   end
 
@@ -17,8 +19,10 @@ class FriendshipsController < ApplicationController
 
     if @friendship.update(friendship_update_params)
       redirect_to users_path
+      flash.notice = 'Friendship successfully updated'
     else
       redirect_to posts_path
+      flash.alert = 'Friendship update unsuccessful'
     end
   end
 


### PR DESCRIPTION
## Friendship update
This pull request seeks to improve the creation and updating of friendships in the app.

Mutual friendship was already implemented in the last milestone through:
- `:check_uniqueness` validation: allows to create a friendship between two users only if no other friendship already exists for these users, no matter who the requester and the requestee are.  
- `#bidirectional_friendship(user1, user2)`: finds a friendship between two users, no matter who the requester/requestee is. This allows filtering the users for whom the 'invite to friendship' option is displayed.
- `#unidirectional_friendship(user2, user2)`: finds a friendship between two users, looking for only one direction.  This allows filtering the users for whom the 'accept' and 'reject' options are displayed, by looking for friendships in which the `current_user` is the requestee. 
